### PR TITLE
Add AudioRubrics: RL with Evolving Rubrics as Rewards for Audio Reasoning (arXiv 2608.02831)

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,8 @@ Overall, this structure follows the lifecycle of rubric-based large-model alignm
 > Self-evolving learning methods let rubrics change during training, using model failures, self-play, memory, or feedback to raise or adjust standards.
 
 ###### 2026
+- 🌟 [[arXiv 2026.08](https://arxiv.org/abs/2608.02831)] Reinforcement Learning with Evolving Rubrics as Rewards for Audio Reasoning [[Proj](https://audiorubrics.github.io)] <br>
+  <img src="https://img.shields.io/static/v1?label=&amp;message=Self-Evolving%20Learning&amp;color=5F6F89&amp;style=flat-square" alt="Self-Evolving Learning"> <img src="https://img.shields.io/static/v1?label=&amp;message=Text%20%2B%20Audio&amp;color=6B8F8F&amp;style=flat-square" alt="Text + Audio">
 - [[arXiv 2026.02](https://arxiv.org/abs/2602.20751)] SibylSense: Adaptive Rubric Learning via Memory Tuning and Adversarial Probing <br>
   <img src="https://img.shields.io/static/v1?label=&amp;message=Rubric%20Grader%20Analysis&amp;color=8A7A5F&amp;style=flat-square" alt="Rubric Grader Analysis"> <img src="https://img.shields.io/static/v1?label=&amp;message=Self-Evolving%20Learning&amp;color=5F6F89&amp;style=flat-square" alt="Self-Evolving Learning">
 - 🌟 [[arXiv 2026.02](https://arxiv.org/abs/2602.10885)] Reinforcing Chain-of-Thought Reasoning with Self-Evolving Rubrics [[Proj](https://alphalab-ustc.github.io/rlcer-alphalab/)] <br>
@@ -1016,6 +1018,8 @@ Overall, this structure follows the lifecycle of rubric-based large-model alignm
 
 ##### 2026
 
+- 🌟 [[arXiv 2026.08](https://arxiv.org/abs/2608.02831)] Reinforcement Learning with Evolving Rubrics as Rewards for Audio Reasoning [[Proj](https://audiorubrics.github.io)] <br>
+  <img src="https://img.shields.io/static/v1?label=&amp;message=Self-Evolving%20Learning&amp;color=5F6F89&amp;style=flat-square" alt="Self-Evolving Learning"> <img src="https://img.shields.io/static/v1?label=&amp;message=Text%20%2B%20Audio&amp;color=6B8F8F&amp;style=flat-square" alt="Text + Audio">
 - [[arXiv 2026.03](https://arxiv.org/abs/2603.16889)] Rubric-Guided Fine-tuning of SpeechLLMs for Multi-Aspect, Multi-Rater L2 Reading-Speech Assessment <br>
   <img src="https://img.shields.io/static/v1?label=&amp;message=Text%20%2B%20Audio&amp;color=6B8F8F&amp;style=flat-square" alt="Text + Audio">
 


### PR DESCRIPTION
Thanks for maintaining this list! I would like to add our recent paper.

**[Reinforcement Learning with Evolving Rubrics as Rewards for Audio Reasoning](https://arxiv.org/abs/2608.02831)** (arXiv 2026.08)
Fangxu Yu, Tao Feng, Dehai Min, Zinan Lin, Weijia Xu, Michael Xu, Philip S. Yu, Ge Liu, Tianyi Zhou
Project page: https://audiorubrics.github.io

AudioRubrics synthesizes question-specific rubrics directly from raw audio waveforms and evolves them during training based on model performance, turning them into a continuous RL reward signal for audio reasoning. It improves over existing reward designs on three benchmarks, with gains scaling with the capability of the rubric generator and evaluator.

### Where it is added

Following the existing convention for cross-cutting papers (e.g. *Visual Preference Optimization with Rubric Rewards*, which is listed under both Preference-Reward RL and Text + Vision), the entry appears in two sections:

- `Training > Post-training > Rubrics for Advanced Training > Self-Evolving Learning > 2026` — the rubrics evolve during training from model failures
- `Applications > Multimodal > Text + Audio > 2026` — the rubrics are grounded in acoustic evidence

Both entries are byte-identical, placed at the top of their 2026 lists by date, and reuse the existing `Self-Evolving Learning` (`5F6F89`) and `Text + Audio` (`6B8F8F`) badge colors. Marked with the star and a `[[Proj]]` link per the repo convention for released project resources.

Happy to move it to a single section or reclassify it if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)