### PR TITLE
Add DrBench deep research benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,8 @@ Overall, this structure follows the lifecycle of rubric-based large-model alignm
 
 ##### 2025
 
+- [[arXiv 2025.10](https://arxiv.org/abs/2510.02190)] A Rigorous Benchmark with Multidimensional Evaluation for Deep Research Agents: From Answers to Reports [[Code](https://github.com/EVIGBYEN/DrBench)] <br>
+  <img src="https://img.shields.io/static/v1?label=&amp;message=Deep%20Research&amp;color=4C8FA3&amp;style=flat-square" alt="Deep Research">
 - 🌟 [[arXiv 2025.12](https://arxiv.org/abs/2512.17776)] DEER: A Benchmark for Evaluating Deep Research Agents on Expert Report Generation [[Code](https://github.com/hanjanghoon/DEER)] <br>
   <img src="https://img.shields.io/static/v1?label=&amp;message=Deep%20Research&amp;color=4C8FA3&amp;style=flat-square" alt="Deep Research">
 - 🌟 [[ICLR 26](https://openreview.net/forum?id=ErnvfmSX0P)] ResearchRubrics: A Benchmark of Prompts and Rubrics For Evaluating Deep Research Agents [[Proj](https://labs.scale.com/papers/researchrubrics)] <br>


### PR DESCRIPTION
## Summary

Adds DrBench to the Deep Research benchmark taxonomy.

## Why

DrBench evaluates deep-research agents on long-form reports with multidimensional quality, topical-focus, and retrieval-trustworthiness assessment.

## Validation

- Verified the paper, arXiv ID, and official code URL.
- Verified no matching README entry or existing issue/PR.
- Ran `git diff --check`.